### PR TITLE
Get a dict of usernames and passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,14 @@ You can get another [properties of an KeePass entry](https://github.com/pschmitt
 (not only `username` or `password`)
 
 Specify a boolean value of true to use custom field properties
+
+If the second parameter is `*` then the whole subtree under the first parameter
+is returned with the leaf entries containing `{ username: password }`.
+_Currently this works only for `_fetch_file`!_
+Given the KeePass DB has the host names in the first group level you could write
+this in `group_vars/all.yml` and get a host-specific dict with user names and 
+passwords:
+
+    dbpasswords: "{{ lookup('keepass', inventory_hostname, '*') }}"
  
 `ansible-doc -t lookup keepass` - to get description of the plugin

--- a/keepass.py
+++ b/keepass.py
@@ -17,7 +17,7 @@ from pykeepass import PyKeePass
 from construct.core import ChecksumError
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-
+#import pprint ### DEBUG
 
 DOCUMENTATION = """
     lookup: keepass
@@ -32,17 +32,25 @@ DOCUMENTATION = """
         description: 
           - first is a path to KeePass entry
           - second is a property name of the entry, e.g. username or password
+          - if second parameter is "*" then the whole subtree under <first_param>
+            is returned with the leaf entries containing { username.. password }
+            (currently this works only for _fetch_file!!)
         required: True
     notes:
       - https://github.com/viczem/ansible-keepass
-    
-    example:
+      - https://github.com/duhlig/ansible-keepass
+
+    examples:
       - "{{ lookup('keepass', 'path/to/entry', 'password') }}"
+      - dbpasswords: "{{ lookup('keepass', inventory_hostname, '*') }}"
 """
 
 
 class LookupModule(LookupBase):
     keepass = None
+    num_groups = 0
+    num_entries = 0
+    #pp = pprint.PrettyPrinter(indent=4) ### DEBUG
 
     def run(self, terms, variables=None, **kwargs):
         if not terms or len(terms) < 2 or len(terms) > 3:
@@ -55,6 +63,7 @@ class LookupModule(LookupBase):
             enable_custom_attr = terms[2]
         
         kp_dbx = variables.get('keepass_dbx', '')
+        display.vvv(u"Keepass: want database file %s" % kp_dbx)
         kp_dbx = os.path.realpath(os.path.expanduser(kp_dbx))
         if os.path.isfile(kp_dbx):
             display.v(u"Keepass: database file %s" % kp_dbx)
@@ -68,9 +77,14 @@ class LookupModule(LookupBase):
         kp_key = variables.get('keepass_key')
         display.v(u"Keepass: fetch from kdbx file")
         return self._fetch_file(
-            kp_dbx, str(kp_psw), kp_key, entry_path, entry_attr, enable_custom_attr)
+                kp_dbx, str(kp_psw), kp_key, entry_path, entry_attr, enable_custom_attr)
 
     def _fetch_file(self, kp_dbx, kp_psw, kp_key, entry_path, entry_attr, enable_custom_attr):
+        try:
+            FileNotFoundError
+        except NameError:
+            FileNotFoundError = IOError
+
         if kp_key:
             kp_key = os.path.realpath(os.path.expanduser(kp_key))
             if os.path.isfile(kp_key):
@@ -79,21 +93,30 @@ class LookupModule(LookupBase):
         try:
             if not LookupModule.keepass:
                 LookupModule.keepass = PyKeePass(kp_dbx, kp_psw, kp_key)
-            entry = LookupModule.keepass.\
-                find_entries_by_path(entry_path, first=True)
-            if entry is None:
-                raise AnsibleError(u"Entry '%s' is not found" % entry_path)
-            display.vv(
-                u"KeePass: attr: %s in path: %s" % (entry_attr, entry_path))
-            entry_val = None
-            if enable_custom_attr:
-                entry_val = entry.get_custom_property(entry_attr)
-                if entry_val is not None:
-                    return [entry_val]
-                else:
-                    raise AnsibleError(AttributeError(u"'No custom field property '%s'" % (entry_attr)))
+            if entry_attr == "*":
+                entry = [ self._getpwtree(LookupModule.keepass.tree.getroot(), entry_path) ]
+                if entry is None:
+                    raise AnsibleError(u"Entry '%s' is not found" % entry_path)
+                display.vv(
+                    u"KeePass: path: %s contains %d groups and %d entries" %
+                    (entry_path, self.num_groups, self.num_entries))
+                return entry
             else:
-                return [getattr(entry, entry_attr)]
+                entry = LookupModule.keepass.\
+                    find_entries_by_path(entry_path, first=True)
+                if entry is None:
+                    raise AnsibleError(u"Entry '%s' is not found" % entry_path)
+                display.vv(
+                    u"KeePass: attr: %s in path: %s" % (entry_attr, entry_path))
+                entry_val = None
+                if enable_custom_attr:
+                    entry_val = entry.get_custom_property(entry_attr)
+                    if entry_val is not None:
+                        return [entry_val]
+                    else:
+                        raise AnsibleError(AttributeError(u"'No custom field property '%s'" % (entry_attr)))
+                else:
+                    return [getattr(entry, entry_attr)]
         except ChecksumError:
             raise AnsibleError("Wrong password/keyfile {}".format(kp_dbx))
         except (AttributeError, FileNotFoundError) as e:
@@ -117,3 +140,84 @@ class LookupModule(LookupBase):
         if msg['status'] == 'error':
             raise AnsibleError(msg['text'])
         return [msg['text']]
+
+    def _getpwtree(self, root, entry_path):
+        if root == None:
+            return None
+        for elem in root:
+            if elem.tag == 'Root':
+                return self._pwtree(elem, entry_path, entry_path == "", True)
+        return None
+
+    def _pwtree(self, elem, entry_path, found, firstgroup):
+        if elem == None:
+            return {}
+        elif elem.tag == 'Entry' and found:
+            return self._getunpw(elem)
+        elif elem.tag == 'Group':
+            return self._getgrp(elem, entry_path, found, firstgroup)
+        else:
+            _pw = {}
+            for subelem in elem:
+                _pw = self._merge_dicts(_pw, self._pwtree(subelem, entry_path, found, firstgroup))
+            return _pw
+
+    def _getgrp(self, grp, entry_path, found, firstgroup):
+        _pw = {}
+        _gname = ""
+        foundnow = False
+        gpath = entry_path.split('/', 1)
+        if len(gpath) == 1:
+            gpath.append("")
+        # first find the group name
+        for attr in grp:
+            if attr.tag == 'Name':
+                if attr.text == 'Recycle Bin':
+                    return {}
+                else:
+                    _gname = attr.text
+        if _gname == "":
+            return {}
+        if not found and gpath[0] == _gname:
+            found = (gpath[1] == "")
+            foundnow = True
+        if firstgroup or found or foundnow:
+            if not firstgroup:
+                entry_path = gpath[1]
+            for attr in grp:
+                _pw = self._merge_dicts(_pw, self._pwtree(attr, entry_path, found, False))
+        if firstgroup or not found or foundnow:
+            return _pw
+        else:
+            self.num_groups += 1
+            return {_gname: _pw}
+
+    def _getunpw(self, entry):
+        idx = -1
+        val = ""
+        unpw = ["", ""]
+        for a in entry:
+            if a.tag == 'String':
+                for kv in a:
+                    if kv.tag == 'Key':
+                        if kv.text == 'UserName':
+                            idx = 0
+                        elif kv.text == 'Password':
+                            idx = 1
+                    elif kv.tag == 'Value':
+                        val = kv.text
+                if idx != -1:
+                    unpw[idx] = val
+                    idx = -1
+        if unpw[0] != "":
+            self.num_entries += 1
+            return {unpw[0]: unpw[1]}
+        else:
+            return {}
+
+    # taken from https://stackoverflow.com/questions/38987/how-do-i-merge-two-dictionaries-in-a-single-expression-in-python
+    def _merge_dicts(self, x, y):
+        """Given two dictionaries, merge them into a new dict as a shallow copy."""
+        z = x.copy()
+        z.update(y)
+        return z


### PR DESCRIPTION
This change was handy for the work with [ansible-oracle](https://github.com/oravirt/ansible-oracle). It allows to read a dict of usernames and passwords grouped by database names and restricted to the current host (given by the structure of the data in the KeePass DB).

The change works for me but I'm afraid it's not very robust at this time. I only tested it with a well formatted KeePass DB, i.e. no whitespace and special characters in group and user names.

Kind Regards,
Dietmar