### PR TITLE
File permissions modified (+x) and changed code to use umask instead of chmod()ing the socket file afterwards.

### DIFF
--- a/kpsock.py
+++ b/kpsock.py
@@ -24,11 +24,11 @@ def main(kdbx, psw, kdbx_key, sock_fpath, ttl=60):
     log = logging.getLogger('ansible_keepass')
 
     try:
+        os.umask(0o177)
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
             s.bind(sock_fpath)
             s.listen(1)
             s.settimeout(ttl)
-            os.chmod(sock_fpath, 0o600)
             log.info('Open ansible-keepass socket. TTL={}sec'.format(ttl))
 
             with PyKeePass(kdbx, psw, kdbx_key) as kp:


### PR DESCRIPTION
I altered the code and use umask() to remove permissions for group/others before creating the socket file. I think this is better than creating the socket first with an undefined user's umask maybe set somewhere in bashrc and later removing permissions, because it leaves a window of opportunity for other users to access the socket, although write permissions are necessary to request a keepass entry.