### PR TITLE
Handle file attached

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: viczem
 name: keepass
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.5.1
+version: 0.6.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/lookup/keepass.py
+++ b/plugins/lookup/keepass.py
@@ -186,6 +186,7 @@ def _keepass_socket(kdbx, kdbx_key, sock_path, ttl=60, kdbx_password=None):
     Socket messages have multiline format.
     First line is a command for both messages are request and response
     """
+    tmp_files = []
     try:
         os.umask(0o177)
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
@@ -302,6 +303,46 @@ def _keepass_socket(kdbx, kdbx_key, sock_path, ttl=60, kdbx_password=None):
                                 )
                             )
                             break
+                        elif prop == "attachment":
+                            if arg_len == 2:
+                                conn.send(
+                                    _resp(
+                                        "fetch",
+                                        1,
+                                        "attachment key is not set "
+                                        "for '%s'".format(arg[0]),
+                                    )
+                                )
+                                break
+
+                            prop_key = arg[2]
+                            attachment = None
+                            for attachment in entry.attachments:
+                                if attachment.filename == prop_key:
+                                    break
+                            if attachment is None:
+                                conn.send(
+                                    _resp(
+                                        "fetch",
+                                        1,
+                                        "attachment '%s' is not found "
+                                        "for '%s'".format(prop_key, path),
+                                    )
+                                )
+                                break
+
+                            tmp_file = tempfile.mkstemp(suffix=f".{attachment.filename}")[1]
+                            with open(tmp_file, "wb") as f:
+                                f.write(attachment.data)
+                            tmp_files.append(tmp_file)
+                            conn.send(
+                                _resp(
+                                    "fetch",
+                                    0,
+                                    tmp_file,
+                                )
+                            )
+                            break
 
                         if not hasattr(entry, prop):
                             conn.send(
@@ -327,6 +368,9 @@ def _keepass_socket(kdbx, kdbx_key, sock_path, ttl=60, kdbx_password=None):
     except KeyboardInterrupt:
         pass
     finally:
+        for tmp_file in tmp_files:
+            if os.path.exists(tmp_file):
+                os.remove(tmp_file)
         if os.path.exists(sock_path):
             os.remove(sock_path)
 

--- a/plugins/lookup/keepass.py
+++ b/plugins/lookup/keepass.py
@@ -21,7 +21,7 @@ from pykeepass.exceptions import CredentialsError
 DOCUMENTATION = """
     lookup: keepass
     author: Victor Zemtsov <viczem.dev@gmail.com>
-    version_added: '0.5.1'
+    version_added: '0.6.0'
     short_description: Fetching data from KeePass file
     description:
         - This lookup returns a value of a property of a KeePass entry


### PR DESCRIPTION
This PR intend to manage files attached to a Keepass entry.

File is retrieved from Keepass db and copied to a temporary file that is automatically removed when socket closes.