### PR TITLE
use sys.executable as path to python

### DIFF
--- a/plugins/lookup/keepass.py
+++ b/plugins/lookup/keepass.py
@@ -93,8 +93,7 @@ class LookupModule(LookupBase):
             os.open(lock_file_, os.O_RDWR)
         except FileNotFoundError:
             cmd = [
-                "/usr/bin/env",
-                "python3",
+                sys.executable,
                 os.path.abspath(__file__),
                 var_dbx,
                 socket_path,


### PR DESCRIPTION
We use a venv for ansible for python. So the old code calls the wrong python which has no python- keepass in the right version