### PR TITLE
Add Bash/Shell environment variables for better ci integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This collection provides plugins that allows to read data from KeePass file (mod
 
 ## How it works
 
-The lookup plugin opens a UNIX socket with decrypted KeePass file. 
-For performance reasons, decryption occurs only once at socket startup, 
+The lookup plugin opens a UNIX socket with decrypted KeePass file.
+For performance reasons, decryption occurs only once at socket startup,
 and the KeePass file remains decrypted as long as the socket is open.
 The UNIX socket file is stored in a temporary folder according to OS.
 
@@ -22,15 +22,36 @@ Requirements: `python 3`, `pykeepass==4.0.3`
 - `keepass_dbx` - path to KeePass file
 - `keepass_psw` - *Optional*. Password (required if `keepass_key` is not set)
 - `keepass_key` - *Optional*. Path to keyfile (required if `keepass_psw` is not set)
-- `keepass_ttl` - *Optional*. Socket TTL (will be closed automatically when not used). 
+- `keepass_ttl` - *Optional*. Socket TTL (will be closed automatically when not used).
 Default 60 seconds.
 
+## Environment Variables
+
+If you want to use ansible-keepass with continuous integration, it could be helpfull not to use ansible variables but Shell enviroment variables.
+
+- `ANSIBLE_KEEPASS_PSW` Password
+- `ANSIBLE_KEEPASS_KEY` Path to keyfile
+- `ANSIBLE_KEEPASS_TTL` Socket TTL
+- `ANSIBLE_KEEPASS_SOCKET` Path to Keepass Socket
+
+The environment variables will only used, if no ansible variable is set.
+
+You can than start the socket in an other background process like this
+```
+export ANSIBLE_KEEPASS_PSW=mySecret
+export ANSIBLE_KEEPASS_SOCKET=/home/build/.my-ansible-sock.${CI_JOB_ID}
+export ANSIBLE_TTL=600 # 10 Minutes
+/home/build/ansible-pyenv/bin/python3 /home/build/.ansible/roles/ansible_collections/viczem/keepass/plugins/lookup/keepass.py /path-to/my-keepass.kdbx &
+ansible-playbook -v playbook1.yml
+ansible-playbook -v playbook2.yml
+
+```
 
 ## Usage
 
 `ansible-doc -t lookup keepass` to get description of the plugin
 
-> **WARNING**: For security reasons, do not store KeePass passwords in plain text. 
+> **WARNING**: For security reasons, do not store KeePass passwords in plain text.
 Use `ansible-vault encrypt_string` to encrypt it and use it like below
 
     # file: group_vars/all

--- a/plugins/lookup/keepass.py
+++ b/plugins/lookup/keepass.py
@@ -72,6 +72,9 @@ class LookupModule(LookupBase):
 
         # Check key file (optional)
         var_key = self._var(variables_.get("keepass_key", ""))
+        if not var_key and "ANSIBLE_KEEPASS_KEY_FILE" in os.environ:
+            var_key = os.environ.get('ANSIBLE_KEEPASS_KEY_FILE')
+
         if var_key:
             var_key = os.path.realpath(os.path.expanduser(os.path.expandvars(var_key)))
             if not os.path.isfile(var_key):
@@ -80,11 +83,17 @@ class LookupModule(LookupBase):
         # Check password (optional)
         var_psw = self._var(variables_.get("keepass_psw", ""))
 
+        if not var_psw and "ANSIBLE_KEEPASS_PSW" in os.environ:
+            var_psw = os.environ.get('ANSIBLE_KEEPASS_PSW')
+
         if not var_key and not var_psw:
             raise AnsibleError("KeePass: 'keepass_psw' and/or 'keepass_key' is not set")
 
         # TTL of keepass socket (optional, default: 60 seconds)
-        var_ttl = self._var(str(variables_.get("keepass_ttl", "60")))
+        default_ttl="60"
+        if "ANSIBLE_KEEPASS_TTL" in os.environ:
+            default_ttl=os.environ.get("ANSIBLE_KEEPASS_TTL")
+        var_ttl = self._var(str(variables_.get("keepass_ttl", default_ttl)))
 
         socket_path = _keepass_socket_path(var_dbx)
         lock_file_ = socket_path + ".lock"
@@ -401,6 +410,9 @@ def _resp(cmd, status_code, payload=""):
 
 def _keepass_socket_path(dbx_path):
     # UNIX socket path for a dbx (supported multiple dbx)
+    if "ANSIBLE_KEEPASS_SOCKET" in os.environ:
+        return os.environ.get('ANSIBLE_KEEPASS_SOCKET')
+    # else:
     tempdir = tempfile.gettempdir()
     if not os.access(tempdir, os.W_OK):
         raise AnsibleError("KeePass: no write permissions to '%s'" % tempdir)
@@ -448,7 +460,13 @@ if __name__ == "__main__":
         password = getpass.getpass("Password: ")
         if isinstance(password, bytes):
             password = password.decode(sys.stdin.encoding)
+    elif "ANSIBLE_KEEPASS_PSW" in os.environ:
+        password = os.environ.get('ANSIBLE_KEEPASS_PSW')
+
+    arg_ttl = args.ttl
+    if arg_ttl is None and "ANSIBLE_KEEPASS_TTL" in os.environ:
+        arg_ttl = os.environ.get('ANSIBLE_KEEPASS_TTL')
 
     os.umask(0o177)
     if lock(arg_kdbx_sock):
-        _keepass_socket(arg_kdbx, arg_key, arg_kdbx_sock, args.ttl, password)
+        _keepass_socket(arg_kdbx, arg_key, arg_kdbx_sock, arg_ttl, password)


### PR DESCRIPTION
If you want to use ansible-keepass with continuous integration, it could be helpfull not to use ansible variables but Shell enviroment variables.

- `ANSIBLE_KEEPASS_PSW` Password
- `ANSIBLE_KEEPASS_KEY` Path to keyfile
- `ANSIBLE_KEEPASS_TTL` Socket TTL
- `ANSIBLE_KEEPASS_SOCKET` Path to Keepass Socket

The environment variables will only used, if no ansible variable is set.

You can than start the socket in an other background process like this
```
export ANSIBLE_KEEPASS_PSW=mySecret
export ANSIBLE_KEEPASS_SOCKET=/home/build/.my-ansible-sock.${CI_JOB_ID}
export ANSIBLE_TTL=600 # 10 Minutes
/home/build/ansible-pyenv/bin/python3 /home/build/.ansible/roles/ansible_collections/viczem/keepass/plugins/lookup/keepass.py /path-to/my-keepass.kdbx &
ansible-playbook -v playbook1.yml
ansible-playbook -v playbook2.yml

```